### PR TITLE
Use gfx_hal 0.1.0

### DIFF
--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
+gfx-hal = "0.1.0"
 fnv = "1.0"
 log = "0.4"

--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
+gfx-hal = "0.1.0"
 derivative = "1.0"
 failure = "0.1"
 relevant = "0.2"

--- a/command/src/buffer/encoder.rs
+++ b/command/src/buffer/encoder.rs
@@ -226,11 +226,11 @@ where
         vertices: std::ops::Range<u32>, 
         instances: std::ops::Range<u32>,
     ) {
-        gfx_hal::command::RawCommandBuffer::draw(
+        unsafe { gfx_hal::command::RawCommandBuffer::draw(
             self.inner.raw,
             vertices,
             instances,
-        )
+        ) }
     }
 
     /// Draw indexed.
@@ -240,12 +240,12 @@ where
         base_vertex: i32, 
         instances: std::ops::Range<u32>,
     ) {
-        gfx_hal::command::RawCommandBuffer::draw_indexed(
+        unsafe { gfx_hal::command::RawCommandBuffer::draw_indexed(
             self.inner.raw,
             indices,
             base_vertex,
             instances,
-        )
+        ) }
     }
 
     /// Draw indirect.
@@ -261,13 +261,13 @@ where
         draw_count: u32, 
         stride: u32,
     ) {
-        gfx_hal::command::RawCommandBuffer::draw_indirect(
+        unsafe { gfx_hal::command::RawCommandBuffer::draw_indirect(
             self.inner.raw,
             buffer,
             offset,
             draw_count,
             stride,
-        )
+        ) }
     }
 }
 

--- a/factory/Cargo.toml
+++ b/factory/Cargo.toml
@@ -21,11 +21,11 @@ rendy-resource = { path = "../resource" }
 rendy-command = { path = "../command" }
 rendy-wsi = { path = "../wsi" }
 
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", optional = true }
+gfx-hal = "0.1.0"
+gfx-backend-empty = { version = "0.1.0", optional = true }
+gfx-backend-dx12 = { version = "0.1.0", optional = true }
+gfx-backend-metal = { version = "0.1.0", optional = true }
+gfx-backend-vulkan = { version = "0.1.0", optional = true }
 
 derivative = "1.0"
 failure = "0.1"

--- a/frame/Cargo.toml
+++ b/frame/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 derivative = "1.0"
 either = "1.5"
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
+gfx-hal = "0.1.0"
 failure = "0.1"
 log = "0.4"
 relevant = "0.2"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -19,11 +19,11 @@ rendy-memory = { path = "../memory" }
 rendy-resource = { path = "../resource" }
 rendy-wsi = { path = "../wsi" }
 
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", optional = true }
+gfx-hal = "0.1.0"
+gfx-backend-empty = { version = "0.1.0", optional = true }
+gfx-backend-dx12 = { version = "0.1.0", optional = true }
+gfx-backend-metal = { version = "0.1.0", optional = true }
+gfx-backend-vulkan = { version = "0.1.0", optional = true }
 
 either = "1.5"
 bitflags = "1.0"

--- a/graph/src/node/render.rs
+++ b/graph/src/node/render.rs
@@ -261,17 +261,18 @@ where
                     .sets
                     .into_iter()
                     .map(|set| {
-                        gfx_hal::Device::create_descriptor_set_layout(
+                        unsafe { gfx_hal::Device::create_descriptor_set_layout(
                             factory.device(),
                             set.bindings,
                             std::iter::empty::<B::Sampler>(),
-                        )
+                        ) }
                     }).collect::<Result<Vec<_>, _>>()?;
-                let pipeline_layout = gfx_hal::Device::create_pipeline_layout(
-                    factory.device(),
-                    &set_layouts,
-                    layout.push_constants,
-                )?;
+                let pipeline_layout = unsafe {
+                    gfx_hal::Device::create_pipeline_layout(
+                        factory.device(),
+                        &set_layouts,
+                        layout.push_constants,
+                    ) }?;
                 Ok((pipeline_layout, set_layouts))
             }).collect::<Result<Vec<_>, failure::Error>>()?
             .into_iter()
@@ -358,12 +359,13 @@ where
                 preserves: &[],
             };
 
-            let result = gfx_hal::Device::create_render_pass(
-                factory.device(),
-                attachments,
-                Some(subpass),
-                std::iter::empty::<gfx_hal::pass::SubpassDependency>(),
-            ).unwrap();
+            let result = unsafe {
+                gfx_hal::Device::create_render_pass(
+                    factory.device(),
+                    attachments,
+                    Some(subpass),
+                    std::iter::empty::<gfx_hal::pass::SubpassDependency>(),
+                ) }.unwrap();
 
             log::trace!("RenderPass instance created for '{}'", R::name());
             result
@@ -416,14 +418,14 @@ where
                     layers: 0..1,
                 };
 
-                gfx_hal::Device::create_image_view(
+                unsafe { gfx_hal::Device::create_image_view(
                     factory.device(),
                     image.image.raw(),
                     view_kind,
                     image.image.format(),
                     gfx_hal::format::Swizzle::NO,
                     subresource_range.clone(),
-                )
+                ) }
             }).collect::<Result<_, _>>()?;
 
         let extent = extent.unwrap_or(gfx_hal::image::Extent {
@@ -503,19 +505,20 @@ where
                 });
 
             let pipelines =
-                gfx_hal::Device::create_graphics_pipelines(factory.device(), descs, None)
+                unsafe { gfx_hal::Device::create_graphics_pipelines(factory.device(), descs, None) }
                     .into_iter()
                     .collect::<Result<Vec<_>, _>>()?;
             log::trace!("Graphics pipeline created for '{}'", R::name());
             pipelines
         };
 
-        let framebuffer = gfx_hal::Device::create_framebuffer(
-            factory.device(),
-            &render_pass,
-            &attachment_views,
-            extent,
-        )?;
+        let framebuffer = unsafe {
+            gfx_hal::Device::create_framebuffer(
+                factory.device(),
+                &render_pass,
+                &attachment_views,
+                extent,
+            ) }?;
 
         let mut command_pool = factory.create_command_pool(family)?
                 .with_capability()

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 serde-1 = ["serde"]
 
 [dependencies]
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
+gfx-hal = "0.1.0"
 derivative = "1.0"
 failure = "0.1"
 log = "0.4"

--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -21,7 +21,7 @@ rendy-resource = { path = "../resource" }
 rendy-factory = { path = "../factory" }
 rendy-util = { path = "../util" }
 
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
+gfx-hal = "0.1.0"
 
 failure = "0.1"
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -39,11 +39,11 @@ rendy-texture = { path = "../texture", optional = true }
 rendy-util = { path = "../util", optional = true }
 rendy-wsi = { path = "../wsi", optional = true }
 
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", optional = true }
+gfx-hal = "0.1.0"
+gfx-backend-empty = { version = "0.1.0", optional = true }
+gfx-backend-dx12 = { version = "0.1.0", optional = true }
+gfx-backend-metal = { version = "0.1.0", optional = true }
+gfx-backend-vulkan = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/rendy/examples/quads/main.rs
+++ b/rendy/examples/quads/main.rs
@@ -202,21 +202,21 @@ where
         let set_layouts = sets[0].as_ref();
         assert_eq!(set_layouts.len(), 1);
 
-        let mut descriptor_pool = gfx_hal::Device::create_descriptor_pool(
+        let mut descriptor_pool = unsafe { gfx_hal::Device::create_descriptor_pool(
             factory.device(),
             1,
             std::iter::once(gfx_hal::pso::DescriptorRangeDesc {
                 ty: gfx_hal::pso::DescriptorType::StorageBuffer,
                 count: 1,
             }),
-        ).unwrap();
+        ) }.unwrap();
 
-        let descriptor_set = gfx_hal::pso::DescriptorPool::allocate_set(
+        let descriptor_set = unsafe { gfx_hal::pso::DescriptorPool::allocate_set(
             &mut descriptor_pool,
             &set_layouts[0],
-        ).unwrap();
+        ) }.unwrap();
 
-        gfx_hal::Device::write_descriptor_sets(
+        unsafe { gfx_hal::Device::write_descriptor_sets(
             factory.device(),
             std::iter::once(gfx_hal::pso::DescriptorSetWrite {
                 set: &descriptor_set,
@@ -224,7 +224,7 @@ where
                 array_offset: 0,
                 descriptors: std::iter::once(gfx_hal::pso::Descriptor::Buffer(posvelbuff.raw(), Some(0) .. Some(posvelbuff.size() as u64))),
             }),
-        );
+        ) }
 
         QuadsRenderPass {
             indirect,
@@ -344,7 +344,7 @@ where
         log::trace!("Load shader module '{:#?}'", *bounce_compute);
         let module = bounce_compute.module(factory)?;
 
-        let set_layout = gfx_hal::Device::create_descriptor_set_layout(
+        let set_layout = unsafe { gfx_hal::Device::create_descriptor_set_layout(
             factory.device(),
             std::iter::once(gfx_hal::pso::DescriptorSetLayoutBinding {
                 binding: 0,
@@ -354,15 +354,15 @@ where
                 immutable_samplers: false,
             }),
             std::iter::empty::<B::Sampler>(),
-        )?;
+        ) }?;
 
-        let pipeline_layout = gfx_hal::Device::create_pipeline_layout(
+        let pipeline_layout = unsafe { gfx_hal::Device::create_pipeline_layout(
             factory.device(),
             std::iter::once(&set_layout),
             std::iter::empty::<(gfx_hal::pso::ShaderStageFlags, std::ops::Range<u32>)>(),
-        )?;
+        ) }?;
 
-        let pipeline = gfx_hal::Device::create_compute_pipeline(
+        let pipeline = unsafe { gfx_hal::Device::create_compute_pipeline(
             factory.device(),
             &gfx_hal::pso::ComputePipelineDesc {
                 shader: gfx_hal::pso::EntryPoint {
@@ -375,7 +375,7 @@ where
                 parent: gfx_hal::pso::BasePipeline::None,
             },
             None,
-        )?;
+        ) }?;
 
         let (descriptor_pool, descriptor_set/*, buffer_view*/) = unsafe {
             let mut descriptor_pool = gfx_hal::Device::create_descriptor_pool(

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["omni-viral <scareaangel@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
+gfx-hal = "0.1.0"
 crossbeam-channel = "0.2"
 derivative = "1.0"
 failure = "0.1"

--- a/resource/src/resources.rs
+++ b/resource/src/resources.rs
@@ -48,7 +48,7 @@ where
             usage: &usage,
         });
 
-        let buf = unsafe {
+        let mut buf = unsafe {
             device.create_buffer(size, usage.flags())
         }?;
         let reqs = unsafe {
@@ -62,8 +62,8 @@ where
             max(reqs.alignment, align),
         )?;
 
-        let buf = unsafe {
-            device.bind_buffer_memory(block.memory(), block.range().start, buf)
+        unsafe {
+            device.bind_buffer_memory(block.memory(), block.range().start, &mut buf)
         }?;
 
         Ok(buffer::Buffer {
@@ -133,7 +133,7 @@ where
             usage: &usage,
         });
 
-        let img = unsafe {
+        let mut img = unsafe {
             device.create_image(
                 kind,
                 levels,
@@ -154,9 +154,8 @@ where
             max(reqs.alignment, align),
         )?;
 
-        let img = unsafe {
-            device
-                .bind_image_memory(block.memory(), block.range().start, img)
+        unsafe {
+            device.bind_image_memory(block.memory(), block.range().start, &mut img)
         }?;
 
         Ok(image::Image {

--- a/shader/Cargo.toml
+++ b/shader/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
+gfx-hal = "0.1.0"
 rendy-factory = { version = "0.1", path = "../factory" }
 shaderc = "0.3"

--- a/shader/src/lib.rs
+++ b/shader/src/lib.rs
@@ -37,8 +37,9 @@ pub trait Shader {
     where
         B: gfx_hal::Backend,
     {
-        gfx_hal::Device::create_shader_module(factory.device(), &self.spirv()?)
-            .map_err(Into::into)
+        unsafe {
+            gfx_hal::Device::create_shader_module(factory.device(), &self.spirv()?)
+        }.map_err(Into::into)
     }
 }
 

--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -19,7 +19,7 @@ rendy-resource = { path = "../resource" }
 rendy-factory = { path = "../factory" }
 rendy-util = { path = "../util" }
 
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
+gfx-hal = "0.1.0"
 
 derivative = "1.0"
 failure = "0.1"

--- a/wsi/Cargo.toml
+++ b/wsi/Cargo.toml
@@ -11,11 +11,11 @@ metal = ["gfx-backend-metal"]
 vulkan = ["gfx-backend-vulkan"]
 
 [dependencies]
-gfx-hal = { git = "https://github.com/gfx-rs/gfx" }
-gfx-backend-empty = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-dx12 = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-metal = { git = "https://github.com/gfx-rs/gfx", optional = true }
-gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx", optional = true }
+gfx-hal = "0.1.0"
+gfx-backend-empty = { version = "0.1.0", optional = true }
+gfx-backend-dx12 = { version = "0.1.0", optional = true }
+gfx-backend-metal = { version = "0.1.0", optional = true }
+gfx-backend-vulkan = { version = "0.1.0", optional = true }
 
 derivative = "1.0"
 failure = "0.1"

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -178,7 +178,7 @@ where
             }
         });
 
-        let (swapchain, backbuffer) = device.create_swapchain(
+        let (swapchain, backbuffer) = unsafe { device.create_swapchain(
             &mut self.raw,
             gfx_hal::SwapchainConfig {
                 present_mode,
@@ -190,7 +190,7 @@ where
                 composite_alpha: gfx_hal::window::CompositeAlpha::Inherit,
             },
             None,
-        )?;
+        ) }?;
 
         Ok(Target {
             relevant: relevant::Relevant,


### PR DESCRIPTION
`gfx_hal` has finally been published, so I updated rendy to use it. It requires adding unsafe blocks in a number of places.