### PR TITLE
Make Pixel repr publicly available. 

### DIFF
--- a/texture/src/pixel.rs
+++ b/texture/src/pixel.rs
@@ -128,7 +128,7 @@ impl_pixel_repr! {
 #[derivative(Clone(bound = ""), Copy(bound = ""), Debug(bound = ""), Default(bound = ""))]
 #[repr(transparent)]
 pub struct Pixel<C, S, T> where C: PixelRepr<S, T> {
-    repr: <C as PixelRepr<S, T>>::Repr,
+    pub repr: <C as PixelRepr<S, T>>::Repr,
 }
 
 /// Pixel trait.


### PR DESCRIPTION
This allows rendy end users to more easily format their pixel data so that it can be consumed by `TextureBuilder.with_data`.