### PR TITLE
Added a function to get the picked format from a surface.

### DIFF
--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -310,6 +310,13 @@ where
         )
     }
 
+    /// Get surface format.
+    pub fn get_surface_format(&self, surface: &Surface<B>) -> gfx_hal::format::Format {
+        unsafe {
+            surface.format(&self.adapter.physical_device)
+        }
+    } 
+
     /// Destroy surface returning underlying window back to the caller.
     pub unsafe fn destroy_surface(&self, surface: Surface<B>) {
         drop(surface);

--- a/rendy/examples/triangle/main.rs
+++ b/rendy/examples/triangle/main.rs
@@ -239,7 +239,7 @@ fn main() {
     let color = graph_builder.create_image(
         surface.kind(),
         1,
-        gfx_hal::format::Format::Rgba8Unorm,
+        factory.get_surface_format(&surface),
         MemoryUsageValue::Data,
         Some(gfx_hal::command::ClearValue::Color([1.0, 1.0, 1.0, 1.0].into())),
     );

--- a/wsi/src/lib.rs
+++ b/wsi/src/lib.rs
@@ -131,6 +131,18 @@ where
         gfx_hal::Surface::kind(&self.raw)
     }
 
+    /// Get surface ideal format.
+    pub unsafe fn format(&self, physical_device: &B::PhysicalDevice) -> gfx_hal::format::Format {
+        let (_capabilities, formats, _present_modes, _alpha) = gfx_hal::Surface::compatibility(&self.raw, physical_device);
+        let formats = formats.unwrap();
+
+        *formats.iter().max_by_key(|format| {
+            let base = format.base_format();
+            let desc = base.0.desc();
+            (!desc.is_compressed(), base.1 == gfx_hal::format::ChannelType::Srgb, desc.bits)
+        }).unwrap()
+    }
+
     /// Cast surface into render target.
     pub unsafe fn into_target(
         mut self,


### PR DESCRIPTION
Added a `get_surface_format` to get the picked surface format to use for `graph_builder.create_image`.