### PR TITLE
Allow `Buffer::map` to run on generic device returned from `Factory::device`

### DIFF
--- a/resource/src/buffer/mod.rs
+++ b/resource/src/buffer/mod.rs
@@ -81,7 +81,7 @@ where
     /// Map range of the buffer to the CPU accessible memory.
     pub fn map<'a>(
         &'a mut self,
-        device: &B::Device,
+        device: &impl gfx_hal::Device<B>,
         range: std::ops::Range<u64>,
     ) -> Result<MappedRange<'a, B>, gfx_hal::mapping::Error> {
         self.escape.1.map(device, range)


### PR DESCRIPTION
Required for this to work
```rust
buffer.map(factory.device(), 0..size)
```