### PR TITLE
Allow storing subpass in rendergroup

### DIFF
--- a/graph/src/node/render/group/mod.rs
+++ b/graph/src/node/render/group/mod.rs
@@ -62,10 +62,17 @@ pub trait RenderGroup<B: Backend, T: ?Sized>: std::fmt::Debug + Send + Sync {
         factory: &Factory<B>,
         queue: QueueId,
         index: usize,
+        subpass: gfx_hal::pass::Subpass<'_, B>,
         aux: &T,
     ) -> PrepareResult;
 
-    fn draw_inline(&mut self, encoder: RenderPassEncoder<'_, B>, index: usize, aux: &T);
+    fn draw_inline(
+        &mut self,
+        encoder: RenderPassEncoder<'_, B>,
+        index: usize,
+        subpass: gfx_hal::pass::Subpass<'_, B>,
+        aux: &T,
+    );
 
     fn dispose(self: Box<Self>, factory: &mut Factory<B>, aux: &mut T);
 }

--- a/graph/src/node/render/group/simple.rs
+++ b/graph/src/node/render/group/simple.rs
@@ -331,13 +331,20 @@ where
         factory: &Factory<B>,
         queue: QueueId,
         index: usize,
+        _subpass: gfx_hal::pass::Subpass<'_, B>,
         aux: &T,
     ) -> PrepareResult {
         self.pipeline
             .prepare(factory, queue, &self.set_layouts, index, aux)
     }
 
-    fn draw_inline(&mut self, mut encoder: RenderPassEncoder<'_, B>, index: usize, aux: &T) {
+    fn draw_inline(
+        &mut self,
+        mut encoder: RenderPassEncoder<'_, B>,
+        index: usize,
+        _subpass: gfx_hal::pass::Subpass<'_, B>,
+        aux: &T,
+    ) {
         encoder.bind_graphics_pipeline(&self.graphics_pipeline);
         self.pipeline
             .draw(&self.pipeline_layout, encoder, index, aux);


### PR DESCRIPTION
I need to (indirectly) store subpass in the rendergroup, because my pipeline defs has to be created lazily based on world state. I coudn't do that, because `RenderGroup` has to be `'static` right now.

EDIT: ~~This is potentially unsound, got a weird warning that should be a compilation error.~~ (should be fixed now)