### PR TITLE
Use serde_bytes in mesh builder

### DIFF
--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [features]
 obj = ["wavefront_obj"]
-serde-1 = ["serde", "gfx-hal/serde", "smallvec/serde", "rendy-factory/serde"]
+serde-1 = ["serde", "serde_bytes", "gfx-hal/serde", "smallvec/serde", "rendy-factory/serde"]
 
 [dependencies]
 rendy-command = { version = "0.1.0", path = "../command" }
@@ -28,3 +28,4 @@ failure = "0.1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 wavefront_obj = { version = "5.1", optional = true }
 smallvec = { version = "0.6" }
+serde_bytes = { version = "0.10.5", optional = true }


### PR DESCRIPTION
This speeds up serialization/deserialization in asset pipeline by some crazy numbers, something like 100x for bigger meshes.