### PR TITLE
Update wavefront_obj

### DIFF
--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -26,6 +26,6 @@ gfx-hal = "0.1"
 
 failure = "0.1"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-wavefront_obj = { version = "5.1", optional = true }
+wavefront_obj = { version = "6.0", optional = true }
 smallvec = { version = "0.6" }
 serde_bytes = { version = "0.10.5", optional = true }

--- a/mesh/src/format/obj.rs
+++ b/mesh/src/format/obj.rs
@@ -9,8 +9,8 @@ use {
 };
 
 /// Load mesh data from obj.
-pub fn load_from_obj(bytes: Vec<u8>, _: ()) -> Result<MeshBuilder<'static>, failure::Error> {
-    let string = String::from_utf8(bytes)?;
+pub fn load_from_obj(bytes: &[u8], _: ()) -> Result<MeshBuilder<'static>, failure::Error> {
+    let string = std::str::from_utf8(bytes)?;
     let set = obj::parse(string).map_err(|e| {
         failure::format_err!(
             "Error during parsing obj-file at line '{}': {}",


### PR DESCRIPTION
The loader also avoids string allocation, because parser can now accept borrowed data.