### PR TITLE
Support texture loading using image crate

### DIFF
--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -36,6 +36,7 @@ base = ["shader-compiler", "command", "factory", "frame", "graph", "memory", "me
 default = ["base"]
 
 mesh-obj = ["mesh", "rendy-mesh/obj"]
+texture-image = ["mesh", "rendy-texture/image"]
 
 full = ["base", "mesh-obj"]
 
@@ -64,7 +65,6 @@ nalgebra = "0.16"
 env_logger = "0.5"
 failure = "0.1"
 lazy_static = "1.0"
-image = "0.20.1"
 log = "0.4"
 winit = "0.18"
 palette = "0.4"

--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -36,9 +36,9 @@ base = ["shader-compiler", "command", "factory", "frame", "graph", "memory", "me
 default = ["base"]
 
 mesh-obj = ["mesh", "rendy-mesh/obj"]
-texture-image = ["mesh", "rendy-texture/image"]
+texture-image = ["texture", "rendy-texture/image"]
 
-full = ["base", "mesh-obj"]
+full = ["base", "mesh-obj", "texture-image"]
 
 [dependencies]
 rendy-command = { version = "0.1.0", path = "../command", optional = true }

--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -24,3 +24,4 @@ gfx-hal = "0.1"
 derivative = "1.0"
 failure = "0.1"
 serde = { version = "1.0", optional = true }
+image = { version = "0.21.0", optional = true }

--- a/texture/src/format.rs
+++ b/texture/src/format.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "image")]
+pub mod image;

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -193,22 +193,20 @@ mod serde_image_format {
         HDR,
     }
 
+    #[derive(Serialize, Deserialize)]
+    struct Helper(#[serde(with = "SerdeImageFormat")] image::ImageFormat);
+
     pub fn serialize<S: Serializer>(
         value: &Option<image::ImageFormat>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        #[derive(Serialize)]
-        struct Helper<'a>(#[serde(with = "SerdeImageFormat")] &'a image::ImageFormat);
-        value.as_ref().map(Helper).serialize(serializer)
+        value.map(Helper).serialize(serializer)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Option<image::ImageFormat>, D::Error> {
-        #[derive(Deserialize)]
-        struct Helper(#[serde(with = "SerdeImageFormat")] image::ImageFormat);
-        let helper = Option::deserialize(deserializer)?;
-        Ok(helper.map(|Helper(external)| external))
+        Ok(Option::deserialize(deserializer)?.map(|Helper(format)| format))
     }
 }
 

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -23,7 +23,6 @@ pub enum LayerLayout {
     Column,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct DataLayout {
     /// distance between lines in texels
     pub line_stride: u32,
@@ -49,12 +48,12 @@ impl LayerLayout {
     fn data_layout(&self, image_width: u32, image_height: u32, layers: u32) -> DataLayout {
         match self {
             LayerLayout::Row => DataLayout {
-                line_stride: image_width * layers,
-                layer_stride: image_width,
+                line_stride: image_width,
+                layer_stride: image_width / layers,
             },
             LayerLayout::Column => DataLayout {
                 line_stride: image_width,
-                layer_stride: image_width * image_height,
+                layer_stride: image_width * image_height / layers,
             },
         }
     }

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -1,0 +1,283 @@
+use crate::{pixel, TextureBuilder};
+use derivative::Derivative;
+pub use image::ImageFormat;
+
+#[derive(Derivative)]
+#[derivative(Default)]
+pub enum Repr {
+    Unorm,
+    Inorm,
+    Uscaled,
+    Iscaled,
+    Uint,
+    Int,
+    #[derivative(Default)]
+    Srgb,
+}
+
+/// Determines the way layers are being stored in source image.
+pub enum LayerLayout {
+    Row,
+    Column,
+}
+
+impl LayerLayout {
+    pub fn layer_width(&self, image_width: u32, layers: u32) -> u32 {
+        match self {
+            LayerLayout::Row => image_width / layers,
+            LayerLayout::Column => image_width,
+        }
+    }
+
+    pub fn layer_height(&self, image_height: u32, layers: u32) -> u32 {
+        match self {
+            LayerLayout::Row => image_height,
+            LayerLayout::Column => image_height / layers,
+        }
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Default)]
+pub enum TextureKind {
+    D1,
+    D1Array,
+    #[derivative(Default)]
+    D2 {
+        #[derivative(Default(value = "1"))]
+        samples: u8,
+    },
+    D2Array {
+        samples: u8,
+        layers: u16,
+        layout: LayerLayout,
+    },
+    D3 {
+        depth: u32,
+        layout: LayerLayout,
+    },
+    Cube {
+        layout: LayerLayout,
+    },
+    CubeArray {
+        layers: u16,
+        layout: LayerLayout,
+    },
+}
+
+impl TextureKind {
+    fn img_kind(&self, width: u32, height: u32) -> gfx_hal::image::Kind {
+        use gfx_hal::image::Kind::*;
+        match self {
+            TextureKind::D1 => D1(width * height, 1),
+            TextureKind::D1Array => D1(width, height as u16),
+            TextureKind::D2 { samples } => D2(width, height, 1, *samples),
+            TextureKind::D2Array {
+                samples,
+                layers,
+                layout,
+            } => D2(
+                layout.layer_width(width, *layers as u32),
+                layout.layer_height(height, *layers as u32),
+                *layers,
+                *samples,
+            ),
+            TextureKind::D3 { depth, layout } => D3(
+                layout.layer_width(width, *depth),
+                layout.layer_height(height, *depth),
+                *depth,
+            ),
+            TextureKind::Cube { layout } => D2(
+                layout.layer_width(width, 6),
+                layout.layer_height(height, 6),
+                6,
+                1,
+            ),
+            TextureKind::CubeArray { layers, layout } => D2(
+                layout.layer_width(width, *layers as u32 * 6),
+                layout.layer_height(height, *layers as u32 * 6),
+                layers * 6,
+                1,
+            ),
+        }
+    }
+
+    fn view_kind(&self) -> gfx_hal::image::ViewKind {
+        use gfx_hal::image::ViewKind;
+        match self {
+            TextureKind::D1 => ViewKind::D1,
+            TextureKind::D1Array { .. } => ViewKind::D1Array,
+            TextureKind::D2 { .. } => ViewKind::D2,
+            TextureKind::D2Array { .. } => ViewKind::D2Array,
+            TextureKind::D3 { .. } => ViewKind::D3,
+            TextureKind::Cube { .. } => ViewKind::Cube,
+            TextureKind::CubeArray { .. } => ViewKind::CubeArray,
+        }
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Default)]
+pub struct ImageTextureConfig {
+    /// Interpret the image as given format.
+    /// When `None`, format is determined automatically based on magic bytes.
+    /// Automatic method doesn't support TGA format.
+    format: Option<ImageFormat>,
+    repr: Repr,
+    kind: TextureKind,
+    #[derivative(Default(value = "gfx_hal::image::Filter::Linear"))]
+    filter: gfx_hal::image::Filter,
+}
+
+macro_rules! set_data {
+    ($builder:expr, $repr:expr, $img:expr) => {
+        match $repr {
+            Repr::Unorm => $builder.set_data(img_into_vec::<pixel::Unorm, _>($img)),
+            Repr::Inorm => $builder.set_data(img_into_vec::<pixel::Inorm, _>($img)),
+            Repr::Uscaled => $builder.set_data(img_into_vec::<pixel::Uscaled, _>($img)),
+            Repr::Iscaled => $builder.set_data(img_into_vec::<pixel::Iscaled, _>($img)),
+            Repr::Uint => $builder.set_data(img_into_vec::<pixel::Uint, _>($img)),
+            Repr::Int => $builder.set_data(img_into_vec::<pixel::Int, _>($img)),
+            Repr::Srgb => $builder.set_data(img_into_vec::<pixel::Srgb, _>($img)),
+        }
+    };
+}
+
+pub fn load_from_image(
+    bytes: &[u8],
+    config: ImageTextureConfig,
+) -> Result<TextureBuilder<'static>, failure::Error> {
+    use image::{DynamicImage, GenericImageView};
+
+    let format = config
+        .format
+        .map_or_else(|| image::guess_format(bytes), |f| Ok(f))?;
+    let image = image::load_from_memory_with_format(bytes, format)?;
+
+    let mut builder = TextureBuilder::new();
+
+    let (w, h) = image.dimensions();
+    builder.set_data_width(w);
+    builder.set_data_height(h);
+    builder.set_kind(config.kind.img_kind(w, h));
+    builder.set_view_kind(config.kind.view_kind());
+    builder.set_filter(config.filter);
+
+    match image {
+        DynamicImage::ImageLuma8(img) => set_data!(builder, config.repr, img),
+        DynamicImage::ImageLumaA8(img) => set_data!(builder, config.repr, img),
+        DynamicImage::ImageRgb8(img) => set_data!(builder, config.repr, img),
+        DynamicImage::ImageRgba8(img) => set_data!(builder, config.repr, img),
+        DynamicImage::ImageBgr8(img) => set_data!(builder, config.repr, img),
+        DynamicImage::ImageBgra8(img) => set_data!(builder, config.repr, img),
+    };
+
+    Ok(builder)
+}
+
+// Types that are representing identical memory layout
+trait CastPixel<R>: image::Pixel + 'static {
+    type Into: pixel::AsPixel;
+}
+
+trait IntoChannels<S, T>
+where
+    S: pixel::ChannelSize,
+    T: pixel::ChannelRepr<S>,
+{
+    type Channels: pixel::PixelRepr<S, T>;
+}
+
+macro_rules! map_channels {
+    {$($colors:ident => $channels:ident),*,} => {
+        $(
+            impl<S, T> IntoChannels<S::Size, T> for image::$colors<S>
+            where
+                S: IntoChannelSize + image::Primitive,
+                T: pixel::ChannelRepr<S::Size>,
+            {
+                type Channels = pixel::$channels;
+            }
+        )*
+    }
+}
+
+map_channels! {
+    Rgba => Rgba,
+    Bgra => Bgra,
+    Rgb => Rgb,
+    Bgr => Bgr,
+    Luma => R,
+    LumaA => Rg,
+}
+
+impl<T, R> CastPixel<R> for T
+where
+    R: pixel::ChannelRepr<<<T as image::Pixel>::Subpixel as IntoChannelSize>::Size> + 'static,
+    T: IntoChannels<<<T as image::Pixel>::Subpixel as IntoChannelSize>::Size, R>
+        + image::Pixel
+        + 'static,
+    T::Subpixel: IntoChannelSize,
+    pixel::Pixel<
+        <T as IntoChannels<<<T as image::Pixel>::Subpixel as IntoChannelSize>::Size, R>>::Channels,
+        <<T as image::Pixel>::Subpixel as IntoChannelSize>::Size,
+        R,
+    >: pixel::AsPixel,
+{
+    type Into = pixel::Pixel<
+        <T as IntoChannels<<<T as image::Pixel>::Subpixel as IntoChannelSize>::Size, R>>::Channels,
+        <<T as image::Pixel>::Subpixel as IntoChannelSize>::Size,
+        R,
+    >;
+}
+
+trait IntoChannelSize {
+    type Size: pixel::ChannelSize;
+}
+
+impl IntoChannelSize for u8 {
+    type Size = pixel::_8;
+}
+impl IntoChannelSize for u16 {
+    type Size = pixel::_16;
+}
+impl IntoChannelSize for u32 {
+    type Size = pixel::_32;
+}
+impl IntoChannelSize for u64 {
+    type Size = pixel::_64;
+}
+
+fn img_into_vec<
+    R: pixel::ChannelRepr<<<P as image::Pixel>::Subpixel as IntoChannelSize>::Size>,
+    P: CastPixel<R>,
+>(
+    img: image::ImageBuffer<P, Vec<<P as image::Pixel>::Subpixel>>,
+) -> Vec<P::Into>
+where
+    <P as image::Pixel>::Subpixel: IntoChannelSize,
+{
+    let len = (img.width() * img.height()) as usize;
+    let mut raw = img.into_raw();
+    let ptr = raw.as_mut_ptr() as *mut P::Into;
+
+    let pixel_size = std::mem::size_of::<P::Into>();
+
+    // When original vector's capacity is not divisible by new type size,
+    // a reallocation is necessary. Otherwise vector cast can be done
+    // and ownership can be transferred without copying.
+    if (raw.capacity() % pixel_size) == 0 {
+        let capacity = raw.capacity() / pixel_size;
+        debug_assert!(capacity >= len);
+        unsafe {
+            let new_vec = Vec::from_raw_parts(ptr, len, capacity);
+            std::mem::forget(raw);
+            new_vec
+        }
+    } else {
+        unsafe {
+            let slice = std::slice::from_raw_parts(ptr, len);
+            slice.to_owned()
+        }
+    }
+}

--- a/texture/src/format/image.rs
+++ b/texture/src/format/image.rs
@@ -1,9 +1,9 @@
 use crate::{pixel, TextureBuilder};
 use derivative::Derivative;
 
-#[derive(Derivative)]
-#[derivative(Default)]
+#[derive(Derivative, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derivative(Default)]
 pub enum Repr {
     Unorm,
     Inorm,
@@ -16,12 +16,14 @@ pub enum Repr {
 }
 
 /// Determines the way layers are being stored in source image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum LayerLayout {
     Row,
     Column,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct DataLayout {
     /// distance between lines in texels
     pub line_stride: u32,
@@ -58,9 +60,9 @@ impl LayerLayout {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Default)]
+#[derive(Derivative, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derivative(Default)]
 pub enum TextureKind {
     D1,
     D1Array,
@@ -159,9 +161,9 @@ impl TextureKind {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Default)]
+#[derive(Derivative, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derivative(Default)]
 pub struct ImageTextureConfig {
     /// Interpret the image as given format.
     /// When `None`, format is determined automatically based on magic bytes.

--- a/texture/src/lib.rs
+++ b/texture/src/lib.rs
@@ -19,5 +19,6 @@ use rendy_util as util;
 
 pub mod pixel;
 mod texture;
+mod format;
 
-pub use crate::{pixel::Rgba8Unorm, texture::*};
+pub use crate::{pixel::Rgba8Unorm, texture::*, format::*};

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -75,7 +75,7 @@ impl<'a> TextureBuilder<'a> {
         data: impl Into<std::borrow::Cow<'a, [u8]>>,
         format: gfx_hal::format::Format,
     ) -> &mut Self {
-        self.data = cast_cow(data.into());
+        self.data = data.into();
         self.format = format;
         self
     }

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -57,6 +57,27 @@ impl<'a> TextureBuilder<'a> {
         self
     }
 
+    /// Set pixel data with manual format definition.
+    pub fn with_raw_data(
+        mut self,
+        data: impl Into<std::borrow::Cow<'a, [u8]>>,
+        format: gfx_hal::format::Format,
+    ) -> Self {
+        self.set_raw_data(data, format);
+        self
+    }
+
+    /// Set pixel data with manual format definition.
+    pub fn set_raw_data(
+        &mut self,
+        data: impl Into<std::borrow::Cow<'a, [u8]>>,
+        format: gfx_hal::format::Format,
+    ) -> &mut Self {
+        self.data = cast_cow(data.into());
+        self.format = format;
+        self
+    }
+
     /// Set pixel data width.
     pub fn with_data_width(mut self, data_width: u32) -> Self {
         self.set_data_width(data_width);

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -25,6 +25,7 @@ pub struct TextureBuilder<'a> {
     data_width: u32,
     data_height: u32,
     filter: gfx_hal::image::Filter,
+    swizzle: gfx_hal::format::Swizzle,
 }
 
 impl<'a> TextureBuilder<'a> {
@@ -38,6 +39,7 @@ impl<'a> TextureBuilder<'a> {
             data_width: 0,
             data_height: 0,
             filter: gfx_hal::image::Filter::Linear,
+            swizzle: gfx_hal::format::Swizzle::NO,
         }
     }
 
@@ -126,7 +128,7 @@ impl<'a> TextureBuilder<'a> {
         self
     }
 
-    /// With image filer.
+    /// With image filter.
     pub fn with_filter(mut self, filter: gfx_hal::image::Filter) -> Self {
         self.set_filter(filter);
         self
@@ -135,6 +137,18 @@ impl<'a> TextureBuilder<'a> {
     /// Set image filter.
     pub fn set_filter(&mut self, filter: gfx_hal::image::Filter) -> &mut Self {
         self.filter = filter;
+        self
+    }
+
+    /// With swizzle.
+    pub fn with_swizzle(mut self, swizzle: gfx_hal::format::Swizzle) -> Self {
+        self.set_swizzle(swizzle);
+        self
+    }
+
+    /// Set swizzle.
+    pub fn set_swizzle(&mut self, swizzle: gfx_hal::format::Swizzle) -> &mut Self {
+        self.swizzle = swizzle;
         self
     }
 
@@ -184,7 +198,7 @@ impl<'a> TextureBuilder<'a> {
             &image,
             self.view_kind,
             self.format,
-            gfx_hal::format::Swizzle::NO,
+            self.swizzle,
             gfx_hal::image::SubresourceRange {
                 aspects: self.format.surface_desc().aspects,
                 levels: 0..1,

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -118,7 +118,7 @@ impl<'a> TextureBuilder<'a> {
     }
 
     /// Build texture.
-    /// 
+    ///
     /// ## Parameters
     /// * `next_state`: The next state that this texture will be used in.
     ///     It will get transitioned to this state after uploading.
@@ -149,13 +149,13 @@ impl<'a> TextureBuilder<'a> {
                 gfx_hal::image::SubresourceLayers {
                     aspects: self.format.surface_desc().aspects,
                     level: 0,
-                    layers: 0..1,
+                    layers: 0..self.kind.num_layers(),
                 },
                 gfx_hal::image::Offset::ZERO,
                 self.kind.extent(),
                 &self.data,
                 gfx_hal::image::Layout::Undefined,
-                next_state
+                next_state,
             )?;
         }
 
@@ -167,7 +167,7 @@ impl<'a> TextureBuilder<'a> {
             gfx_hal::image::SubresourceRange {
                 aspects: self.format.surface_desc().aspects,
                 levels: 0..1,
-                layers: 0..1,
+                layers: 0..self.kind.num_layers(),
             },
         )?;
 


### PR DESCRIPTION
This adds a possibility to load various image formats directly into a texture builder.

This code is probably wrong for any texture kind except 2D, because I don't really get the way how layers are treated in memory.