### PR TITLE
[WIP] Improve `load_from_image` and TextureBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 **/*.rs.bk
 **/Cargo.lock
 .DS_Store
+**/.vscode

--- a/factory/src/factory.rs
+++ b/factory/src/factory.rs
@@ -205,6 +205,22 @@ where
             .upload_buffer(&self.device, buffer, offset, staging, last, next)
     }
 
+    pub unsafe fn transition_image(
+        &self,
+        image: &mut Image<B>,
+        range: gfx_hal::image::SubresourceRange,
+        last: impl Into<ImageStateOrLayout>,
+        next: ImageState,
+    ) -> Result<(), failure::Error> {
+        self.uploader.transition_image(
+            &self.device,
+            image,
+            range,
+            last.into(),
+            next,
+        )
+    }
+
     /// Upload image.
     ///
     /// # Safety

--- a/factory/src/upload.rs
+++ b/factory/src/upload.rs
@@ -238,6 +238,8 @@ where
 
         let mut encoder = next_upload.command_buffer.encoder();
 
+        log::trace!("Transition image: {:?} \n    Range: {:?}\n    Last: {:?}\n    Next: {:?}", image, range, last, next);
+
         match last.into() {
             ImageStateOrLayout::State(last) => {
                 if last.queue != next.queue {

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -57,6 +57,7 @@ struct SpriteGraphicsPipeline<B: gfx_hal::Backend> {
     descriptor_set: B::DescriptorSet,
 }
 
+#[cfg(feature = "texture-image")]
 impl<B, T> SimpleGraphicsPipelineDesc<B, T> for SpriteGraphicsPipelineDesc
 where
     B: gfx_hal::Backend,
@@ -266,6 +267,7 @@ where
     }
 }
 
+#[cfg(feature = "texture-image")]
 impl<B, T> SimpleGraphicsPipeline<B, T> for SpriteGraphicsPipeline<B>
 where
     B: gfx_hal::Backend,

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -19,6 +19,8 @@ use rendy::{
     texture::{Texture},
 };
 
+use gfx_hal::{Device, DescriptorPool};
+
 use winit::{EventsLoop, WindowBuilder};
 
 #[cfg(feature = "dx12")]
@@ -306,9 +308,11 @@ where
         encoder.draw(0..6, 0..1);
     }
 
-    fn dispose(self, _factory: &mut Factory<B>, _aux: &mut T) {
-        self.descriptor_pool.reset();
-        factory.destroy_descriptor_pool(self.descriptor_pool);
+    fn dispose(mut self, factory: &mut Factory<B>, _aux: &mut T) {
+        unsafe {
+            self.descriptor_pool.reset();
+            factory.destroy_descriptor_pool(self.descriptor_pool);
+        }
     }
 }
 

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -14,7 +14,7 @@ use rendy::{
     graph::{present::PresentNode, render::*, Graph, GraphBuilder, NodeBuffer, NodeImage},
     memory::MemoryUsageValue,
     mesh::{AsVertex, PosTex},
-    resource::buffer::Buffer,
+    resource::{buffer::Buffer, image::TextureUsage},
     shader::{Shader, ShaderKind, SourceLanguage, StaticShaderInfo},
     texture::{Texture},
 };
@@ -157,7 +157,9 @@ where
 
         let texture_builder = rendy::texture::image::load_from_image(
             std::io::BufReader::new(image_file),
-            Default::default()
+            Default::default(),
+            TextureUsage,
+            factory.physical(),
         )?;
 
         let texture = texture_builder
@@ -169,6 +171,7 @@ where
                     layout: gfx_hal::image::Layout::ShaderReadOnlyOptimal,
                 },
                 factory,
+                TextureUsage,
             )
             .unwrap();
 

--- a/rendy/examples/sprite/main.rs
+++ b/rendy/examples/sprite/main.rs
@@ -148,12 +148,15 @@ where
         assert_eq!(set_layouts.len(), 1);
 
         // This is how we can load an image and create a new texture.
-        let image_bytes = include_bytes!(concat!(
+        let image_file = std::fs::File::open(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/examples/sprite/logo.png"
-        ));
+        ))?;
 
-        let texture_builder = rendy::texture::image::load_from_image(image_bytes, Default::default())?;
+        let texture_builder = rendy::texture::image::load_from_image(
+            std::io::BufReader::new(image_file),
+            Default::default()
+        )?;
 
         let texture = texture_builder
             .build(
@@ -303,7 +306,10 @@ where
         encoder.draw(0..6, 0..1);
     }
 
-    fn dispose(self, _factory: &mut Factory<B>, _aux: &mut T) {}
+    fn dispose(self, _factory: &mut Factory<B>, _aux: &mut T) {
+        self.descriptor_pool.reset();
+        factory.destroy_descriptor_pool(self.descriptor_pool);
+    }
 }
 
 #[cfg(any(feature = "dx12", feature = "metal", feature = "vulkan"))]

--- a/resource/src/image/usage.rs
+++ b/resource/src/image/usage.rs
@@ -9,6 +9,22 @@ pub trait Usage: std::fmt::Debug {
     /// Convert usage to the flags.
     fn flags(&self) -> gfx_hal::image::Usage;
 
+    /// Convert to needed image features
+    fn features(&self) -> gfx_hal::format::ImageFeature {
+        let mut features = gfx_hal::format::ImageFeature::empty();
+        let usage = self.flags();
+        if usage.contains(gfx_hal::image::Usage::COLOR_ATTACHMENT) {
+            features |= gfx_hal::format::ImageFeature::COLOR_ATTACHMENT;
+        }
+        if usage.contains(gfx_hal::image::Usage::SAMPLED) {
+            features |= gfx_hal::format::ImageFeature::SAMPLED;
+        }
+        if usage.contains(gfx_hal::image::Usage::STORAGE) {
+            features |= gfx_hal::format::ImageFeature::STORAGE;
+        }
+        features
+    }
+
     /// Get suggested memory usage.
     fn memory(&self) -> Self::MemoryUsage;
 }
@@ -31,10 +47,10 @@ where
 /// Type that specify that image is intended to be used as texture.
 /// It implies `TRANSFER_DST` because device-local, host-invisible memory should be used
 /// and transfer is left the only way to fill the buffer.
-#[derive(Clone, Copy, Debug)]
-pub struct Texture;
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TextureUsage;
 
-impl Usage for Texture {
+impl Usage for TextureUsage {
     type MemoryUsage = Data;
 
     fn flags(&self) -> gfx_hal::image::Usage {
@@ -47,7 +63,7 @@ impl Usage for Texture {
 }
 
 /// Type that specify that image is intended to be used as render target and storage image.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct RenderTargetStorage;
 
 impl Usage for RenderTargetStorage {
@@ -63,7 +79,7 @@ impl Usage for RenderTargetStorage {
 }
 
 /// Type that specify that image is intended to be used as render target and sampled image.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct RenderTargetSampled;
 
 impl Usage for RenderTargetSampled {

--- a/resource/src/resources.rs
+++ b/resource/src/resources.rs
@@ -377,8 +377,9 @@ fn match_kind(
             gfx_hal::image::ViewKind::D1 | gfx_hal::image::ViewKind::D1Array => true,
             _ => false,
         },
-        gfx_hal::image::Kind::D2(..) => match view_kind {
-            gfx_hal::image::ViewKind::D2 | gfx_hal::image::ViewKind::D2Array => true,
+        gfx_hal::image::Kind::D2(..) => match (view_kind, view_caps) {
+            (gfx_hal::image::ViewKind::Cube, caps) if caps.contains(gfx_hal::image::ViewCapabilities::KIND_CUBE) => true,
+            (gfx_hal::image::ViewKind::D2, _) | (gfx_hal::image::ViewKind::D2Array, _) => true,
             _ => false,
         },
         gfx_hal::image::Kind::D3(..) => {

--- a/texture/Cargo.toml
+++ b/texture/Cargo.toml
@@ -12,6 +12,7 @@ description = "Rendy's texture"
 
 [features]
 serde-1 = ["serde", "gfx-hal/serde", "rendy-factory/serde"]
+default = ["image"]
 
 [dependencies]
 rendy-memory = { version = "0.1.0", path = "../memory" }

--- a/texture/src/texture.rs
+++ b/texture/src/texture.rs
@@ -80,6 +80,24 @@ impl<'a> TextureBuilder<'a> {
         self
     }
 
+    /// Set pixel format
+    pub fn set_raw_format(
+        &mut self,
+        format: gfx_hal::format::Format,
+    ) -> &mut Self {
+        self.format = format;
+        self
+    }
+
+    /// Set pixel format
+    pub fn with_raw_format(
+        mut self,
+        format: gfx_hal::format::Format,
+    ) -> Self {
+        self.set_raw_format(format);
+        self
+    }
+
     /// Set pixel data width.
     pub fn with_data_width(mut self, data_width: u32) -> Self {
         self.set_data_width(data_width);
@@ -172,7 +190,10 @@ impl<'a> TextureBuilder<'a> {
             1,
             self.format,
             gfx_hal::image::Tiling::Optimal,
-            gfx_hal::image::ViewCapabilities::empty(),
+            match self.view_kind {
+                gfx_hal::image::ViewKind::Cube => gfx_hal::image::ViewCapabilities::KIND_CUBE,
+                _ => gfx_hal::image::ViewCapabilities::empty(),
+            },
             TextureUsage,
         )?;
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -42,6 +42,10 @@ pub fn is_slice_sorted_by_key<'a, T, K: Ord>(slice: &'a [T], f: impl Fn(&'a T) -
 }
 
 /// Cast vec of some arbitrary type into vec of bytes.
+/// 
+/// This is technically Undefined Behavior but on the default
+/// system allocators for all major OS's and WASM at this time
+/// it doesn't actually cause problems for any T with align <= 8
 pub fn cast_vec<T: Copy>(mut vec: Vec<T>) -> Vec<u8> {
     let len = std::mem::size_of::<T>() * vec.len();
     let cap = std::mem::size_of::<T>() * vec.capacity();
@@ -58,6 +62,10 @@ pub fn cast_slice<T>(slice: &[T]) -> &[u8] {
 }
 
 /// Cast `cow` of some arbitrary type into `cow` of bytes.
+/// 
+/// This is technically Undefined Behavior but on the default
+/// system allocators for all major OS's and WASM at this time
+/// it doesn't actually cause problems for any T with align <= 8
 pub fn cast_cow<T: Copy>(cow: Cow<'_, [T]>) -> Cow<'_, [u8]> {
     match cow {
         Cow::Borrowed(slice) => Cow::Borrowed(cast_slice(slice)),


### PR DESCRIPTION
Currently, HDR files only get loaded as LDR representations. This adds a special path for HDR files when Repr is Float which correctly loads the HDR image.

Also, uses reader instead of raw data buffer and adds support for cubemap textures in TextureBuilder