### PR TITLE
Fix allocator disposal error message

### DIFF
--- a/descriptor/src/allocator.rs
+++ b/descriptor/src/allocator.rs
@@ -120,8 +120,8 @@ where
             assert!(pool.freed + pool.free <= pool.size);
             if pool.freed + pool.free < pool.size {
                 log::error!(
-                    "Descriptor pools are still in use during allocator disposal. {:?}",
-                    self.pools
+                    "Descriptor pool is still in use during allocator disposal. {:?}",
+                    pool
                 );
             } else {
                 log::trace!("Destroying used up descriptor pool");


### PR DESCRIPTION
`self.pools` doesn't contain the pool that triggered the error, and errors are repeated for each pool anyway.