### PR TITLE
Fix dynamic allocator.

### DIFF
--- a/factory/src/config.rs
+++ b/factory/src/config.rs
@@ -138,7 +138,7 @@ unsafe impl HeapsConfigure for BasicHeapsConfigure {
         self,
         properties: &gfx_hal::adapter::MemoryProperties,
     ) -> (Self::Types, Self::Heaps) {
-        let _32mb = 32 * 1024 * 1024;
+        let _16mb = 16 * 1024 * 1024;
         let _256mb = 256 * 1024 * 1024;
 
         let types = properties
@@ -161,14 +161,18 @@ unsafe impl HeapsConfigure for BasicHeapsConfigure {
                     },
                     dynamic: Some(DynamicConfig {
                         max_block_size: min(
-                            _32mb,
-                            properties.memory_heaps[mt.heap_index as usize] / 8,
+                            _16mb,
+                            properties.memory_heaps[mt.heap_index as usize] / 32,
                         ),
                         block_size_granularity: min(
                             256,
                             properties.memory_heaps[mt.heap_index as usize] / 1024,
                         ),
                         blocks_per_chunk: 64,
+                        max_chunk_size: min(
+                            _256mb,
+                            properties.memory_heaps[mt.heap_index as usize] / 8,
+                        ),
                     }),
                 };
 


### PR DESCRIPTION
Dynamic allocator max allocation now picked from config.
Add max chunk size to config to prevent it from trying to allocate too big chunks resulting in OOM
Fixes #84 