### PR TITLE
Only require `&Factory` in MeshBuilder::build

### DIFF
--- a/mesh/src/mesh.rs
+++ b/mesh/src/mesh.rs
@@ -199,11 +199,7 @@ impl<'a> MeshBuilder<'a> {
     }
 
     /// Builds and returns the new mesh.
-    pub fn build<B>(
-        &self,
-        queue: QueueId,
-        factory: &mut Factory<B>,
-    ) -> Result<Mesh<B>, failure::Error>
+    pub fn build<B>(&self, queue: QueueId, factory: &Factory<B>) -> Result<Mesh<B>, failure::Error>
     where
         B: gfx_hal::Backend,
     {

--- a/rendy/examples/meshes/main.rs
+++ b/rendy/examples/meshes/main.rs
@@ -477,7 +477,7 @@ fn main() {
         Mesh::<Backend>::builder()
             .with_indices(&indices[..])
             .with_vertices(&vertices[..])
-            .build(graph.node_queue(pass), &mut factory)
+            .build(graph.node_queue(pass), &factory)
             .unwrap(),
     );
 


### PR DESCRIPTION
Little change so that one can upload meshes from within a render node.