### PR TITLE
Fix no-slow-safety-checks warning in factory

### DIFF
--- a/rendy/Cargo.toml
+++ b/rendy/Cargo.toml
@@ -17,7 +17,7 @@ dx12 = ["rendy-factory/dx12", "rendy-graph/dx12", "rendy-wsi/dx12", "gfx-backend
 metal = ["rendy-factory/metal", "rendy-graph/metal", "rendy-wsi/metal", "gfx-backend-metal", "rendy-util/metal"]
 vulkan = ["rendy-factory/vulkan", "rendy-graph/vulkan", "rendy-wsi/vulkan", "gfx-backend-vulkan", "rendy-util/vulkan"]
 serde-1 = ["gfx-hal/serde", "rendy-factory/serde-1", "rendy-mesh/serde-1", "rendy-texture/serde-1", "rendy-shader/serde-1"]
-no-slow-safety-checks = ["rendy-util/no-slow-safety-checks"]
+no-slow-safety-checks = ["rendy-util/no-slow-safety-checks", "rendy-factory/no-slow-safety-checks"]
 shader-compiler = ["rendy-shader/shader-compiler"]
 
 command = ["rendy-command"]


### PR DESCRIPTION
Previously [this line](https://github.com/omni-viral/rendy/blob/master/factory/src/factory.rs#L974) would trigger even if the `no-slow-safety-checks` feature was activated in rendy.